### PR TITLE
Fix: About button opens multiple dialogs

### DIFF
--- a/UnrealBinaryBuilder/MainWindow.xaml.cs
+++ b/UnrealBinaryBuilder/MainWindow.xaml.cs
@@ -1699,7 +1699,8 @@ namespace UnrealBinaryBuilder
 		private void AboutBtn_Click(object sender, RoutedEventArgs e)
 		{
 			GameAnalyticsCSharp.AddDesignEvent("AboutDialog:Open");
-			aboutDialog = Dialog.Show(new AboutDialog(this));
+			if (aboutDialog is null || aboutDialog.IsClosed)
+				aboutDialog = Dialog.Show(new AboutDialog(this));
 		}
 
 		public void CloseAboutDialog()


### PR DESCRIPTION
When clicking on about button more than one time, it opens a new dialog when closing it the old one can't be closed which forces the user to restart the app.